### PR TITLE
fix: github pages theme

### DIFF
--- a/.github/theme.md.gotmpl
+++ b/.github/theme.md.gotmpl
@@ -1,10 +1,8 @@
-name: AXIVO Helm Charts
-page-title: AXIVO Helm Charts
 title: AXIVO Helm Charts
 theme: jekyll-theme-primer
 description: Kubernetes Helm charts for deploying applications with ArgoCD
 keywords: argocd, kubernetes, helm, chart, container, devops
-baseurl: ""
+baseurl: "/charts"
 url: https://axivo.github.io/charts
 footer_content: ""
 github:


### PR DESCRIPTION
## Objective

Fix the baseURL into Jekyll theme.

## Scope

- [x] Bug (resolves an issue)
- [ ] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new issues or warnings
